### PR TITLE
expose debug, improve documentation in settings, make functions private in python, remove weird debug stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,14 +187,23 @@ to update the following areas:
     your plugin to expose a javascript function the returns a list of filament and what tool they
     represent.
 
+### Debugging
+
+Enable debug logs via the settings menu, ensure logging is set to the debug level for prusammu.
+
+Octoprint exposes the viewmodel via:
+```javascript
+> OctoPrint.coreui.viewmodels.prusaMMU2ViewModel
+```
+
 ### Building
 
 You can manually build this project into a zip by running:
 ```
-$ bash build.sh [VERSION DEBUG]
+$ bash build.sh [VERSION]
 
 # ex:
-$ bash build.sh 2022.7.4 n
+$ bash build.sh 2022.7.4
 === Building PrusaMMU ===
 
 Settings:

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!usr/bin/env bash
 
-# bash build.sh YYYY.M.D n
+# bash build.sh YYYY.M.D
 
 echo "=== Building PrusaMMU ===";
 echo "";
@@ -11,7 +11,6 @@ echo "Settings:";
 version="${1:-$dt}";
 debug="${2:-y}";
 echo "- Version: $version";
-echo "- Debug $debug";
 echo ""
 
 # Delete and recreate the build directory
@@ -33,14 +32,6 @@ cp setup.py Octoprint-PrusaMmu/setup.py
 echo -n "Writing plugin version... "
 sed -i "s/plugin_version = \"VERSION\"/plugin_version = \"$version\"/" Octoprint-PrusaMmu/setup.py
 echo "done"
-
-# Disable debugs
-if [ "$debug" == "n" ]; then
-  echo -n "Disabling debug... " 
-  sed -i 's/DEBUG = true/DEBUG = false/' Octoprint-PrusaMmu/octoprint_prusammu/static/prusammu.js
-  sed -i 's/NOISY_DEBUG = True/NOISY_DEBUG = False/' Octoprint-PrusaMmu/octoprint_prusammu/__init__.py
-  echo "done"
-fi
 
 # Compress the build directory
 echo -n "Zipping... ";

--- a/octoprint_prusammu/__init__.py
+++ b/octoprint_prusammu/__init__.py
@@ -14,10 +14,6 @@ from octoprint_prusammu.common.PluginEventKeys import PluginEventKeys
 from octoprint_prusammu.common.SettingsKeys import SettingsKeys
 from octoprint_prusammu.common.StateKeys import StateKeys, DEFAULT_STATE
 
-
-# turning this on will cause every log write to surface as a console.log
-NOISY_DEBUG = True
-
 # === Constants ===
 DEFAULT_TIMEOUT = 30
 PLUGIN_NAME = "prusammu"
@@ -57,24 +53,24 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
   # ======== Startup ========
 
   def on_after_startup(self):
-    self.log("on_after_startup")
+    self._log("on_after_startup")
     
     try:
       # After startup set the sources we have available
       # TODO: Move this out of settings
       sources = FILAMENT_SOURCE_DEFAULT
       if "filamentmanager" in self._plugin_manager.plugins:
-        self.log("Found Filament Manager")
+        self._log("Found Filament Manager")
         sources.append(dict(name="Filament Manager", id="filamentManager"))
       if "SpoolManager" in self._plugin_manager.plugins:
-        self.log("Found Spool Manager")
+        self._log("Found Spool Manager")
         sources.append(dict(name="Spool Manager", id="spoolManager"))
       self._settings.set([SettingsKeys.FILAMENT_SOURCES], sources)
       self._settings.save()
     except Exception as e:
-      self.log("Failed to load sources {}".format(str(e)))
+      self._log("Failed to load sources {}".format(str(e)))
 
-    self.refresh_config()
+    self._refresh_config()
     self.mmu = DEFAULT_MMU_STATE
 
   # ======== TemplatePlugin ========
@@ -111,15 +107,15 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
       if not isinstance(choice, int) or not choice < 5 or not choice >= 0:
         return abort(400, "{} is not a valid value for filament choice".format(choice+1))
 
-      self.log("on_api_command T{}".format(choice), debug=True)
-      self.fire_event(PluginEventKeys.MMU_CHANGE, dict(tool=choice))
+      self._log("on_api_command T{}".format(choice), debug=True)
+      self._fire_event(PluginEventKeys.MMU_CHANGE, dict(tool=choice))
       self._done_prompt(choice)
 
     if command == "getmmu":
       if not user_permission.can():
         return abort(403, "Insufficient permissions")
       
-      self.fire_event(PluginEventKeys.REFRESH_NAV)
+      self._fire_event(PluginEventKeys.REFRESH_NAV)
 
 
   # ======== Prompt ========
@@ -142,7 +138,7 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
     self._clean_up_prompt()
 
   def _done_prompt(self, command, tags=set()):
-    self.log("_done_prompt {}".format(command), debug=True)
+    self._log("_done_prompt {}".format(command), debug=True)
     self.states[StateKeys.SELECTED_FILAMENT] = command
     self._clean_up_prompt()
 
@@ -154,8 +150,8 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
 
   # ======== Nav Updater ========
 
-  def update_navbar(self):
-    self.log("update_navbar:", obj=self.mmu, debug=True)
+  def _update_navbar(self):
+    self._log("update_navbar:", obj=self.mmu, debug=True)
     self._plugin_manager.send_plugin_message(
       self._identifier,
       dict(
@@ -181,22 +177,22 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
       return # passthrough
 
     if cmd.startswith("M109"):
-      self.log("gcode_queuing_hook_M109 command: {}".format(cmd), debug=True)
+      self._log("gcode_queuing_hook_M109 command: {}".format(cmd), debug=True)
       if self.states[StateKeys.SELECTED_FILAMENT] is not None:
         tool_cmd = "T{}".format(self.states[StateKeys.SELECTED_FILAMENT])
-        self.fire_event(PluginEventKeys.MMU_CHANGE,
+        self._fire_event(PluginEventKeys.MMU_CHANGE,
                         dict(tool=self.states[StateKeys.SELECTED_FILAMENT]))
         self.states[StateKeys.SELECTED_FILAMENT] = None
-        self.log("gcode_queuing_hook_M109 tool: {}".format(tool_cmd), debug=True)
+        self._log("gcode_queuing_hook_M109 tool: {}".format(tool_cmd), debug=True)
         return[(cmd,), (tool_cmd,)] # rewrite (append tool command)
       else:
         return # passthrough
 
     # Prompt for filament change
     if cmd.startswith("Tx"):
-      self.log("gcode_queuing_hook {}".format(cmd), debug=True)
+      self._log("gcode_queuing_hook {}".format(cmd), debug=True)
       if self._printer.set_job_on_hold(True):
-        self.fire_event(PluginEventKeys.SHOW_PROMPT)
+        self._fire_event(PluginEventKeys.SHOW_PROMPT)
       return None, # suppress
 
     return # passthrough
@@ -207,19 +203,19 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
       # The printer will spam pause messages directly after an attention so ignore them
       if self.mmu[MmuKeys.STATE] == MmuStates.ATTENTION:
         return line
-      self.fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.PAUSED_USER))
+      self._fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.PAUSED_USER))
     elif "MMU => 'start'" in line:
-      self.fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.STARTING))
+      self._fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.STARTING))
     elif "MMU not responding" in line:
-      self.fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.ATTENTION))
+      self._fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.ATTENTION))
     elif "MMU - ENABLED" in line or "MMU starts responding" in line:
-      self.fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.OK))
+      self._fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.OK))
     elif "MMU can_load" in line or "Unloading finished" in line:
-      self.fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.LOADING))
+      self._fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.LOADING))
     # elif "mmu_get_response - begin move: unload" in line:
-    #   self.fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.UNLOADING))
+    #   self._fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.UNLOADING))
     elif "OO succeeded" in line:
-      self.fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.LOADED))
+      self._fire_event(PluginEventKeys.MMU_CHANGE, dict(state=MmuStates.LOADED))
 
     return line
 
@@ -244,15 +240,15 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
 
       # Show unloading if there's already a tool loaded and it's not the same tool
       if self.mmu[MmuKeys.STATE] == MmuStates.LOADED and self.mmu[MmuKeys.TOOL] != tool:
-        self.fire_event(PluginEventKeys.MMU_CHANGE,
+        self._fire_event(PluginEventKeys.MMU_CHANGE,
                         dict(state=MmuStates.UNLOADING,
                              tool=tool,
                              previousTool=self.mmu[MmuKeys.TOOL]))
         return
 
       # Otherwise assume it's a first time load
-      self.fire_event(PluginEventKeys.MMU_CHANGE, dict(tool=tool))
-      self.log("gcode_sent_hook Tool: {} CMD: {}".format(tool, cmd), debug=True)
+      self._fire_event(PluginEventKeys.MMU_CHANGE, dict(tool=tool))
+      self._log("gcode_sent_hook Tool: {} CMD: {}".format(tool, cmd), debug=True)
     except:
       pass
 
@@ -260,7 +256,7 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
 
   # ======== EventHandlerPlugin ========
 
-  def fire_event(self, key, payload=None):
+  def _fire_event(self, key, payload=None):
     self._event_bus.fire(key, payload=payload)
 
 
@@ -275,12 +271,12 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
   def on_event(self, event, payload=None):
     # This is fired at the end of the change event, we dont need it but other plugins might
     # if event == PluginEventKeys.MMU_CHANGED:
-    #   self.log("on_event {} with".format(event, obj=payload, debug=True)
+    #   self._log("on_event {} with".format(event, obj=payload, debug=True)
     #   return
 
     # Fired any time we detect a command that would update something about the MMU
     if event == PluginEventKeys.MMU_CHANGE:
-      self.log("on_event {} with".format(event), obj=payload, debug=True)
+      self._log("on_event {} with".format(event), obj=payload, debug=True)
       if MmuKeys.STATE not in payload:
         payload[MmuKeys.STATE] = self.mmu[MmuKeys.STATE]
       if MmuKeys.TOOL not in payload:
@@ -298,26 +294,26 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
         state=None if MmuKeys.STATE not in payload else payload[MmuKeys.STATE],
         tool=None if MmuKeys.TOOL not in payload else payload[MmuKeys.TOOL],
         previousTool=None if MmuKeys.PREV_TOOL not in payload else payload[MmuKeys.PREV_TOOL])
-      self.fire_event(PluginEventKeys.MMU_CHANGED, self.mmu)
-      self.update_navbar()
+      self._fire_event(PluginEventKeys.MMU_CHANGED, self.mmu)
+      self._update_navbar()
       return
 
     # Fired to cause a refresh event on the UI
     if event == PluginEventKeys.REFRESH_NAV:
-      self.log("on_event {}".format(event), debug=True)
-      self.update_navbar()
+      self._log("on_event {}".format(event), debug=True)
+      self._update_navbar()
       return
 
     # Fired to prompt the user to select a filament
     if event == PluginEventKeys.SHOW_PROMPT:
-      self.log("on_event {}".format(event), debug=True)
+      self._log("on_event {}".format(event), debug=True)
       self._show_prompt()
       return
 
     # Handle disconenced event to set the mmu to Not Found (no printer...)
     if event == "Disconnected":
-      self.log("on_event {}".format(event), debug=True)
-      self.fire_event(PluginEventKeys.MMU_CHANGE,
+      self._log("on_event {}".format(event), debug=True)
+      self._fire_event(PluginEventKeys.MMU_CHANGE,
                       dict(state= MmuStates.NOT_FOUND, tool="", previousTool=""))
 
     # Handle terminal states when printer is no longer printing to reset the MMU
@@ -326,19 +322,21 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
       event == Events.PRINT_CANCELLED or
       (event == Events.PRINT_FAILED and self.mmu[MmuKeys.STATE] != MmuStates.ATTENTION)
     ):
-      self.log("on_event {}".format(event), debug=True)
-      self.fire_event(PluginEventKeys.MMU_CHANGE,
+      self._log("on_event {}".format(event), debug=True)
+      self._fire_event(PluginEventKeys.MMU_CHANGE,
                       dict(state=MmuStates.OK, tool="", previousTool=""))
 
   # ======== SettingsPlugin ========
 
   def get_settings_defaults(self):
     return dict(
+      debug=False,
       timeout=DEFAULT_TIMEOUT,
       useDefaultFilament=False,
       displayActiveFilament=True,
       simpleDisplayMode=False,
       defaultFilament=-1,
+      indexAtZero=False,
       filamentSource=PLUGIN_NAME,
       filamentSources=FILAMENT_SOURCE_DEFAULT,
       filament=[
@@ -374,13 +372,14 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
     if SettingsKeys.GCODE_FILAMENT not in data:
       data[SettingsKeys.GCODE_FILAMENT] = self._settings.get([SettingsKeys.GCODE_FILAMENT])
 
-    self.log("on_settings_save", debug=True)
+    self._log("on_settings_save", debug=True)
 
     # save settings
     octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
-    self.refresh_config()
+    self._refresh_config()
 
-  def refresh_config(self):
+  def _refresh_config(self):
+    self.config[SettingsKeys.DEBUG] = self._settings.get_boolean([SettingsKeys.DEBUG])
     self.config[SettingsKeys.SIMPLE_DISPLAY_MODE] = self._settings.get_boolean([
       SettingsKeys.SIMPLE_DISPLAY_MODE])
 
@@ -400,7 +399,7 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
   
   def get_update_information(self):
     githubUrl = "https://github.com/jukebox42/Octoprint-PrusaMMU"
-    pipPath = "/releases/{target_version}/download/Octoprint-PrusaMmu.zip"
+    pipPath = "/releases/download/{target_version}/Octoprint-PrusaMmu.zip"
     # Define the configuration for your plugin to use with the Software Update.
     return dict(
 	    PrusaMMU=dict(
@@ -420,9 +419,9 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
 
   # ======== Misc ========
 
-  def log(self, msg, obj=None, debug=False):
+  def _log(self, msg, obj=None, debug=False):
     if debug:
-      if NOISY_DEBUG:
+      if self.config[SettingsKeys.DEBUG]:
         if obj is not None:
           msg = "{} {}".format(msg, dumps(obj))
         self._logger.debug(msg)

--- a/octoprint_prusammu/common/SettingsKeys.py
+++ b/octoprint_prusammu/common/SettingsKeys.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 
 class SettingsKeys():
+  DEBUG="debug"
   TIMEOUT="timeout"
   USE_DEFAULT_FILAMENT="useDefaultFilament"
   DISPLAY_ACTIVE_FILAMENT="displayActiveFilament"

--- a/octoprint_prusammu/templates/prusammu_navbar.jinja2
+++ b/octoprint_prusammu/templates/prusammu_navbar.jinja2
@@ -18,6 +18,3 @@
   "></i>
   <span data-bind="text: navActionText, hidden: isSimpleDisplayMode"></span>
 </a>
-<a href="javascript:void(0)" data-bind="click: openDebugSettings, if: debug()" style="position: absolute; left: -40px; top: 0; display: inline-block;">
-  <i class="fas fa-bug"></i>
-</a>

--- a/octoprint_prusammu/templates/prusammu_settings.jinja2
+++ b/octoprint_prusammu/templates/prusammu_settings.jinja2
@@ -1,6 +1,6 @@
 <h2>{{ _("Prusa MMU") }}</h2>
 <form class="form-horizontal">
-  <h3>{{ _("Filament Labels") }}</h3>
+  <h3>{{ _("Filament") }}</h3>
 
   <div class="control-group">
     <label class="control-label">{{ _("Filament Label Source") }}</label>
@@ -22,6 +22,7 @@
 
       <div class="alert alert-block" data-bind="visible: settings.plugins.prusammu.filamentSource() == 'spoolManager'">
         <p><strong>Spool Manager:</strong><br /> {{ _("To manage filament use the Spool tab and select the correct tool each filament spool is connected to.") }}</p>
+        <p style="color:red">{{ _("IMPORTANT: You must disable 'Reminder for verifying the selected spool.' under Notification in the Spool Manager settings or the select filament feature will not work.") }}</p>
       </div>
 
       <div class="alert alert-block" data-bind="visible: settings.plugins.prusammu.filamentSource() == 'filamentManager'">
@@ -38,7 +39,7 @@
   <div data-bind="visible: settings.plugins.prusammu.filamentSource() == 'prusammu'">
     <div data-bind="foreach: settings.plugins.prusammu.filament">
       <div class="control-group">
-        <label class="control-label"><strong data-bind="text: $index() + 1"></strong></label>
+        <label class="control-label"><strong data-bind="text: $index() + ($parent.settings.plugins.prusammu.indexAtZero() ? 0 : 1)"></strong></label>
         <div class="controls">
           <input type="checkbox" data-bind="checked: $data.enabled" />
           <input type="text" data-bind="value: $data.name" />
@@ -46,6 +47,16 @@
           <input type="color" class="input-mini" data-bind="value: $data.color" />
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <div class="controls">
+      <label class="checkbox">
+        <input type="checkbox" data-bind="checked: settings.plugins.prusammu.indexAtZero" />
+        {{ _("Index at zero") }}
+      </label>
+      <span class="help-block">{{ _("Check to have the filament numbers be 0-4 instead of 1-5. Plugins like Spool Manager as well as the actual gcode refrence them as 0-4.") }}</span>
     </div>
   </div>
 
@@ -71,7 +82,10 @@
         enable: settings.plugins.prusammu.useDefaultFilament,
         options: settings.plugins.prusammu.filament,
         optionsText: function(fill) {
-          return 'Filament ' + fill.id() + ': ' + fill.name()
+          if(settings.plugins.prusammu.filamentSource() == 'prusammu') {
+           return 'Filament ' + (settings.plugins.prusammu.indexAtZero() ? fill.id() - 1 : fill.id()) + ': ' + fill.name()
+          }
+          return 'Filament ' + (settings.plugins.prusammu.indexAtZero() ? fill.id() - 1 : fill.id())
         },
         optionsValue: function(fill) {
           return fill.id() - 1
@@ -89,9 +103,9 @@
     <div class="controls">
       <label class="checkbox">
         <input type="checkbox" data-bind="checked: settings.plugins.prusammu.displayActiveFilament" />
-        {{ _("Display In Navbar") }}
+        {{ _("Display in navbar") }}
       </label>
-      <span class="help-block">{{ _("Note: Displaying the active filament in the navbar can be unreliable at times. The tool information cannot be retrieved during a print, it's only reported during a change. Instead, we try to remember decisions made and save it so it's available on subsequent loads.") }}</span>
+      <span class="help-block">{{ _("Check if you want to see the active filament as well as MMU state change in the navbar.") }}</span>
     </div>
   </div>
 
@@ -99,9 +113,21 @@
     <div class="controls">
       <label class="checkbox">
         <input type="checkbox" data-bind="checked: settings.plugins.prusammu.simpleDisplayMode" />
-        {{ _("Simple Display Mode") }}
+        {{ _("Simple display mode") }}
       </label>
       <span class="help-block">{{ _("Check to remove the text from the navbar item to save space.") }}</span>
+    </div>
+  </div>
+
+  <h3>{{ _("Debug") }}</h3>
+
+  <div class="control-group">
+    <div class="controls">
+      <label class="checkbox">
+        <input type="checkbox" data-bind="checked: settings.plugins.prusammu.debug" />
+        {{ _("Debug") }}
+      </label>
+      <span class="help-block">{{ _("Warning: Enabling debug will make Prusa MMU noisy in logs and devtools. May also slow down your print.") }}</span>
     </div>
   </div>
 


### PR DESCRIPTION
A PR all about cleanup and adding debug

To test download the file below and install manually using the Plugin Manager.

[Octoprint-PrusaMmu.zip](https://github.com/jukebox42/Octoprint-PrusaMMU/files/9378165/Octoprint-PrusaMmu.zip) (new as of 8/18)



New Features:
- [x] Exposed Debug as a setting
- [x] Improved descriptions in settings

Bug Fixes:
- [x] TBD SpoolManager fix

Piping
- [x] Cleaned up debug, removing the weird stuff(moved shortcut button to a different plugin)
- [x] Made functions private in python, I plan to do another pass in JS later to stop polluting the view object