### PR TITLE
fixing the download link

### DIFF
--- a/octoprint_prusammu/__init__.py
+++ b/octoprint_prusammu/__init__.py
@@ -400,7 +400,7 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
   
   def get_update_information(self):
     githubUrl = "https://github.com/jukebox42/Octoprint-PrusaMMU"
-    pipPath = "/releases/{target_version}/download/Octoprint-PrusaMmu.zip"
+    pipPath = "/releases/download/{target_version}/Octoprint-PrusaMmu.zip"
     # Define the configuration for your plugin to use with the Software Update.
     return dict(
 	    PrusaMMU=dict(


### PR DESCRIPTION
Download link is currently broken in all versions. Fixing ita

Fixed in 2022.8.17. Any user impacted will need to re-download.

Fixes:
- https://github.com/jukebox42/Octoprint-PrusaMMU/issues/13
- https://github.com/OctoPrint/plugins.octoprint.org/issues/1101