### PR TITLE
Enhanced mmu 3.0.0 support.

### DIFF
--- a/mmuTestStrings.txt
+++ b/mmuTestStrings.txt
@@ -1,0 +1,57 @@
+========================
+===== MMU 2: 1.0.0 =====
+========================
+
+# Starting
+!!DEBUG:send MMU => 'start'
+
+# Enabled (ready)
+!!DEBUG:send MMU - ENABLED
+!!DEBUG:send MMU starts responding
+
+# Paused
+!!DEBUG:send paused for user
+
+# Not responding
+!!DEBUG:send MMU not responding
+
+# Loading
+!!DEBUG:send MMU can_load:
+!!DEBUG:send Unloading finished 2
+
+# Loaded
+!!DEBUG:send OOOOOOOOOOOOOOOOOOOOOOOOOOO succeeded.
+
+
+========================
+===== MMU 2: 3.0.0 =====
+========================
+Note: Make sure you don't send the *XX at the end of lines. Virtual printer loses it's mind if you do.
+
+# Starting / init (must be in not found mode)
+!!DEBUG:send Recv: Cap:PRUSA_MMU2:1
+!!DEBUG:send MMU2:<X0 F0
+
+# Error
+!!DEBUG:send MMU2:<L0 E800d
+
+# Button (must be in error mode)
+!!DEBUG:send MMU2:Button
+
+# OK (must be in error mode)
+!!DEBUG:send MMU2:OK
+
+# Unload Start (must not be in unloading)
+!!DEBUG:send MMU2:<U1 A0
+
+# Unload Finished (must be in unloading)
+!!DEBUG:send MMU2:<U1 F0 
+
+# Load Start (must not be in loading)
+!!DEBUG:send MMU2:Feeding to FINDA
+!!DEBUG:send MMU2:<:L2 P0
+
+# Load Finished (must be in loading unless using the last one)
+!!DEBUG:send MMU2:Disengaging idler
+!!DEBUG:send ResetRetryAttempts
+!!DEBUG:send MMU2:<T2 F0

--- a/octoprint_prusammu/common/Mmu.py
+++ b/octoprint_prusammu/common/Mmu.py
@@ -15,13 +15,18 @@ class MmuStates():
 
 class MmuKeys():
   STATE="state"
+  LIVE_STATE="liveState"
   TOOL="tool"
   PREV_TOOL="previousTool"
+  ERROR="error"
 
 DEFAULT_MMU_STATE = dict(
+  # liveState represents the state we have yet to advertise. Used to avoid event spamming with 3.0.0
+  liveState=MmuStates.NOT_FOUND,
   state=MmuStates.NOT_FOUND,
   tool="",
   previousTool="",
+  error="",
 )
 
 class MMU2Commands():
@@ -42,25 +47,28 @@ class MMU2Commands():
 # Using this we can determine:
 # The MMU (F)inished (L)oading Tool 0, and it only took 0(one) tries.
 class MMU3Codes():
+  INIT="MMU2:<X[0-4] F"
+  VERSION="MMU2<S3 A"
+  # Error
+  ERROR="MMU2:<(?:[^E]*) (E[^*]*)"
   # Tool
   # TODO: What's the different between Tool Finished and Load Finished? I don't see Load Finished in multi-color prints.
-  TOOL_START="MMU[23]:<T[0-4] A"
-  TOOL_PROCESSING="MMU[23]:<T[0-4] P"
-  TOOL_FINISHED="MMU[23]:<T[0-4] F0"
+  TOOL_START="MMU2:<T[0-4] A"
+  TOOL_PROCESSING="MMU2:<T[0-4] P"
+  TOOL_FINISHED="MMU2:<T[0-4] F"
   # Load
-  LOAD_START="MMU[23]:<L[0-4] A"
-  LOAD_PROCESSING="MMU[23]:<:L[0-4] P"
-  LOAD_FINISHED="MMU[23]:<L[0-4] F"
+  LOAD_START="MMU2:<L[0-4] A"
+  LOAD_PROCESSING="MMU2:<:L[0-4] P"
+  LOAD_FINISHED="MMU2:<L[0-4] F"
   # Unload
-  UNLOAD_START="MMU[23]:<U[0-4] A"
-  UNLOAD_PROCESSING="MMU[23]:<U[0-4] P"
-  UNLOAD_FINISHED="MMU[23]:<U[0-4] F"
+  UNLOAD_START="MMU2:<U[0-4] A"
+  UNLOAD_PROCESSING="MMU2:<U[0-4] P"
+  UNLOAD_FINISHED="MMU2:<U[0-4] F"
 
 class MMU3Commands():
   INIT="Cap:PRUSA_MMU2:1"
   ERROR="MMU2:Command Error"
   BUTTON="MMU2:Button"
-  READ="MMU2:<"
   # Not technically an MMU command but tells us the last action was successful probably.
   RESET_RETRY="ResetRetryAttempts"
   # https://github.com/prusa3d/Prusa-Firmware/blob/d84e3a9cf31963b9378b9cf39cd3dd4c948a05d6/Firmware/mmu2_progress_converter.cpp#L8

--- a/octoprint_prusammu/static/mmuErrors.js
+++ b/octoprint_prusammu/static/mmuErrors.js
@@ -1,0 +1,372 @@
+/**
+ * Given an error code it finds the corresponding error in the MMU2MmuErrorStrings map.
+ * TODO: This will lie to owners not running 3.0.0 as it'll always return an UNKNOWN for them.
+ * 
+ * @param {string} code - The string identifier for the error. Will be "E" followed by a 4 digit hex code.
+ * @returns 
+ */
+const getMmuError = (code) => {
+  try {
+    if (!code) {
+      return MMU2MmuErrorStrings["UNKNOWN"];
+    }
+
+    if (MMU2MmuErrorStrings[code]) {
+      return MMU2MmuErrorStrings[code];
+    }
+  } catch (e) { console.error(e); }
+
+  return MMU2MmuErrorStrings["UNKNOWN"];
+};
+
+/**
+ * The map below's keys come from:
+ * https://github.com/prusa3d/Prusa-Firmware/blob/4c531630686b4918ae442a27dce67c01f351c757/Firmware/mmu2/error_codes.h
+ * mapped by 
+ * https://github.com/prusa3d/Prusa-Firmware/blob/MK3/Firmware/mmu2_error_converter.cpp
+ * to
+ * https://raw.githubusercontent.com/prusa3d/Prusa-Error-Codes/master/04_MMU/error-codes.yaml
+ * 
+ * Missing codes or ones I couldn't figure out how to map start with an X.
+ */
+const MMU2MmuErrorStrings = {
+  // MECHANICAL
+  E8001: {
+    code:"04101",
+    title:"FINDA DIDNT TRIGGER",
+    text:"FINDA didn't trigger while loading the filament. Ensure the filament can move and FINDA works.",
+    id:"FINDA_DIDNT_TRIGGER",
+  },
+
+  E8002: {
+    code:"04102",
+    title:"FINDA FILAM. STUCK",
+    text:"FINDA didn't switch off while unloading filament. Try unloading manually. Ensure filament can move and FINDA works.",
+    id:"FINDA_FILAMENT_STUCK",
+  },
+
+  E8003 : {
+    code:"04103",
+    title:"FSENSOR DIDNT TRIGG.",
+    text:"Filament sensor didn't trigger while loading the filament. Ensure the sensor is calibrated and the filament reached it.",
+    id:"FSENSOR_DIDNT_TRIGGER",
+  },
+
+  E8004: {
+    code:"04104",
+    title:"FSENSOR FIL. STUCK",
+    text:"Filament sensor didn't switch off while unloading filament. Ensure filament can move and the sensor works.",
+    id:"FSENSOR_FILAMENT_STUCK",
+  },
+
+  /*X04105: {
+    code:"04105",
+    title:"PULLEY CANNOT MOVE",
+    text:"Pulley motor stalled. Ensure the pulley can move and check the wiring.",
+    id:"PULLEY_CANNOT_MOVE",
+  },*/
+
+  E8009: {
+    code:"04106",
+    title:"FSENSOR TOO EARLY",
+    text:"Filament sensor triggered too early while loading to extruder. Check there isn't anything stuck in PTFE tube. Check that sensor reads properly.",
+    id:"FSENSOR_TOO_EARLY",
+  },
+
+  E800a: {
+    code:"04107",
+    title:"INSPECT FINDA",
+    text:"Selector can't move due to FINDA detecting a filament. Make sure no filament is in Selector and FINDA works properly.",
+    id:"INSPECT_FINDA",
+  },
+
+  /*E802a: {
+    code:"04108",
+    title:"LOAD TO EXTR. FAILED",
+    text:"Loading to extruder failed. Inspect the filament tip shape. Refine the sensor calibration, if needed.",
+    id:"LOAD_TO_EXTRUDER_FAILED",
+  },*/
+
+  /*X04115: {
+    code:"04115",
+    title:"SELECTOR CANNOT HOME",
+    text:"The Selector cannot home properly. Check for anything blocking its movement.",
+    id:"SELECTOR_CANNOT_HOME",
+  },*/
+
+  /*X04116: {
+    code:"04116",
+    title:"SELECTOR CANNOT MOVE",
+    text:"The Selector cannot move. Check for anything blocking its movement. Check if the wiring is correct.",
+    id:"SELECTOR_CANNOT_MOVE",
+  },*/
+
+  /*X04125: {
+    code:"04125",
+    title:"IDLER CANNOT HOME",
+    text:"The Idler cannot home properly. Check for anything blocking its movement.",
+    id:"IDLER_CANNOT_HOME",
+  },*/
+
+  /*X04126: {
+    code:"04126",
+    title:"IDLER CANNOT MOVE",
+    text:"The Idler cannot move properly. Check for anything blocking its movement. Check if the wiring is correct.",
+    id:"IDLER_CANNOT_MOVE",
+  },*/
+
+  // TEMPERATURE    xx2xx   // Temperature measurement
+
+  EA000: {
+    code:"04201",
+    title:"WARNING TMC TOO HOT",
+    text:"TMC driver for the Pulley motor is almost overheating. Make sure there is sufficient airflow near the MMU board.",
+    text_short:"More details online.",
+    id:"WARNING_TMC_PULLEY_TOO_HOT",
+  },
+
+  /*EA000: {
+    code:"04211",
+    title:"WARNING TMC TOO HOT",
+    text:"TMC driver for the Selector motor is almost overheating. Make sure there is sufficient airflow near the MMU board.",
+    text_short:"More details online.",
+    id:"WARNING_TMC_SELECTOR_TOO_HOT",
+  },
+
+  EA000: {
+    code:"04221",
+    title:"WARNING TMC TOO HOT",
+    text:"TMC driver for the Idler motor is almost overheating. Make sure there is sufficient airflow near the MMU board.",
+    text_short:"More details online.",
+    id:"WARNING_TMC_IDLER_TOO_HOT",
+  },*/
+
+  EC000: {
+    code:"04202",
+    title:"TMC OVERHEAT ERROR",
+    text:"TMC driver for the Pulley motor is overheated. Cool down the MMU board and reset MMU.",
+    text_short:"More details online.",
+    id:"TMC_PULLEY_OVERHEAT_ERROR",
+  },
+
+  /*EC000: {
+    code:"04212",
+    title:"TMC OVERHEAT ERROR",
+    text:"TMC driver for the Selector motor is overheated. Cool down the MMU board and reset MMU.",
+    text_short:"More details online.",
+    id:"TMC_SELECTOR_OVERHEAT_ERROR",
+  },
+
+  EC000: {
+    code:"04222",
+    title:"TMC OVERHEAT ERROR",
+    text:"TMC driver for the Idler motor is overheated. Cool down the MMU board and reset MMU.",
+    text_short:"More details online.",
+    id:"TMC_IDLER_OVERHEAT_ERROR",
+  },*/
+
+  // ELECTRICAL     xx3xx
+
+  E8200: {
+    code:"04301",
+    title:"TMC DRIVER ERROR",
+    text:"TMC driver for the Pulley motor is not responding. Try resetting the MMU. If the issue persists contact support.",
+    text_short:"More details online.",
+    id:"TMC_PULLEY_DRIVER_ERROR",
+  },
+
+  /*E8200: {
+    code:"04311",
+    title:"TMC DRIVER ERROR",
+    text:"TMC driver for the Selector motor is not responding. Try resetting the MMU. If the issue persists contact support.",
+    text_short:"More details online.",
+    id:"TMC_SELECTOR_DRIVER_ERROR",
+  },
+
+  E8200: {
+    code:"04321",
+    title:"TMC DRIVER ERROR",
+    text:"TMC driver for the Idler motor is not responding. Try resetting the MMU. If the issue persists contact support.",
+    text_short:"More details online.",
+    id:"TMC_IDLER_DRIVER_ERROR",
+  },*/
+
+  E8400: {
+    code:"04302",
+    title:"TMC DRIVER RESET",
+    text:"TMC driver for the Pulley motor was restarted. There is probably an issue with the electronics. Check the wiring and connectors.",
+    text_short:"More details online.",
+    id:"TMC_PULLEY_DRIVER_RESET",
+  },
+
+  /*E8400: {
+    code:"04312",
+    title:"TMC DRIVER RESET",
+    text:"TMC driver for the Selector motor was restarted. There is probably an issue with the electronics. Check the wiring and connectors.",
+    text_short:"More details online.",
+    id:"TMC_SELECTOR_DRIVER_RESET",
+  },
+
+  E8400: {
+    code:"04322",
+    title:"TMC DRIVER RESET",
+    text:"TMC driver for the Idler motor was restarted. There is probably an issue with the electronics. Check the wiring and connectors.",
+    text_short:"More details online.",
+    id:"TMC_IDLER_DRIVER_RESET",
+  },*/
+
+  E8800: {
+    code:"04303",
+    title:"TMC UNDERVOLTAGE ERR",
+    text:"Not enough current for the Pulley TMC driver. There is probably an issue with the electronics. Check the wiring and connectors.",
+    text_short:"More details online.",
+    id:"TMC_PULLEY_UNDERVOLTAGE_ERROR",
+  },
+
+  /*E8800: {
+    code:"04313",
+    title:"TMC UNDERVOLTAGE ERR",
+    text:"Not enough current for the Selector TMC driver. There is probably an issue with the electronics. Check the wiring and connectors.",
+    text_short:"More details online.",
+    id:"TMC_SELECTOR_UNDERVOLTAGE_ERROR",
+  },
+
+  E8800: {
+    code:"04323",
+    title:"TMC UNDERVOLTAGE ERR",
+    text:"Not enough current for the Idler TMC driver. There is probably an issue with the electronics. Check the wiring and connectors.",
+    text_short:"More details online.",
+    id:"TMC_IDLER_UNDERVOLTAGE_ERROR",
+  },*/
+
+  E9000: {
+    code:"04304",
+    title:"TMC DRIVER SHORTED",
+    text:"Short circuit on the Pulley TMC driver. Check the wiring and connectors. If the issue persists contact support.",
+    text_short:"More details online.",
+    id:"TMC_PULLEY_DRIVER_SHORTED",
+  },
+
+  /*E9000: {
+    code:"04314",
+    title:"TMC DRIVER SHORTED",
+    text:"Short circuit on the Selector TMC driver. Check the wiring and connectors. If the issue persists contact support.",
+    text_short:"More details online.",
+    id:"TMC_SELECTOR_DRIVER_SHORTED",
+  },
+
+  E9000: {
+    code:"04324",
+    title:"TMC DRIVER SHORTED",
+    text:"Short circuit on the Idler TMC driver. Check the wiring and connectors. If the issue persists contact support.",
+    text_short:"More details online.",
+    id:"TMC_IDLER_DRIVER_SHORTED",
+  },*/
+
+  EC200: {
+    code:"04305",
+    title:"MMU SELFTEST FAILED",
+    text:"MMU selftest failed on the Pulley TMC driver. Check the wiring and connectors. If the issue persists contact support.",
+    text_short:"More details online.",
+    id:"MMU_PULLEY_SELFTEST_FAILED",
+  },
+
+  /*EC200: {
+    code:"04315",
+    title:"MMU SELFTEST FAILED",
+    text:"MMU selftest failed on the Selector TMC driver. Check the wiring and connectors. If the issue persists contact support.",
+    text_short:"More details online.",
+    id:"MMU_SELECTOR_SELFTEST_FAILED",
+  },
+
+  EC200: {
+    code:"04325",
+    title:"MMU SELFTEST FAILED",
+    text:"MMU selftest failed on the Idler TMC driver. Check the wiring and connectors. If the issue persists contact support.",
+    text_short:"More details online.",
+    id:"MMU_IDLER_SELFTEST_FAILED",
+  },*/
+
+  E800d: {
+    code:"04306",
+    title:"MMU MCU ERROR",
+    text:"MMU detected a power-related issue. Check the wiring and connectors. If the issue persists, contact support.",
+    text_short:"More details online.",
+    id:"MCU_POWER_ERROR",
+  },
+
+  // CONNECTIVITY
+
+  E802e: {
+    code:"04401",
+    title:"MMU NOT RESPONDING",
+    text:"MMU not responding. Check the wiring and connectors.",
+    id:"MMU_NOT_RESPONDING",
+  },
+
+  E802d: {
+    code:"04402",
+    title:"COMMUNICATION ERROR",
+    text:"MMU not responding correctly. Check the wiring and connectors.",
+    id:"COMMUNICATION_ERROR",
+  },
+
+  // SYSTEM
+
+  E8005: {
+    code:"04501",
+    title:"FIL. ALREADY LOADED",
+    text:"Cannot perform the action, filament is already loaded. Unload it first.",
+    id:"FILAMENT_ALREADY_LOADED",
+  },
+
+  E8006: {
+    code:"04502",
+    title:"INVALID TOOL",
+    text:"Requested filament tool is not available on this hardware. Check the G-code for tool index out of range (T0-T4},.",
+    id:"INVALID_TOOL",
+  },
+
+  E802b: {
+    code:"04503",
+    title:"QUEUE FULL",
+    text:"MMU Firmware internal error, please reset the MMU.",
+    id:"QUEUE_FULL",
+  },
+
+  E802c: {
+    code:"04504",
+    title:"MMU FW UPDATE NEEDED",
+    text:"The MMU firmware version is incompatible with the printer's FW. Update to compatible version.",
+    text_short:"MMU FW version is incompatible with printer FW.Update to version 3.0.0.",
+    id:"FW_UPDATE_NEEDED",
+  },
+
+  E802f: {
+    code:"04505",
+    title:"FW RUNTIME ERROR",
+    text:"Internal runtime error. Try resetting the MMU or updating the firmware.",
+    id:"FW_RUNTIME_ERROR",
+  },
+
+  E8008: {
+    code:"04506",
+    title:"UNLOAD MANUALLY",
+    text:"Filament detected unexpectedly. Ensure no filament is loaded. Check the sensors and wiring.",
+    id:"UNLOAD_MANUALLY",
+  },
+
+  E800c: {
+    code:"04507",
+    title:"FILAMENT EJECTED",
+    text:"Remove the ejected filament from the front of the MMU.",
+    id:"FILAMENT_EJECTED",
+  },
+
+  UNKNOWN: {
+    code:"04900",
+    title:"UNKNOWN ERROR",
+    text:"Unexpected error occurred.",
+    id:"UNKNOWN_ERROR",
+  },
+};

--- a/octoprint_prusammu/templates/prusammu_settings.jinja2
+++ b/octoprint_prusammu/templates/prusammu_settings.jinja2
@@ -1,6 +1,10 @@
 <h2>{{ _("Prusa MMU") }}</h2>
-<div class="alert alert-block">
-  <p><strong>Warning:</strong><br /> {{ _("First version with MMU2 3.0.0 support. If you find a bug please let me know.") }}</p>
+<div id="prusammu_error_zone" class="hide">
+  <div class="alert alert-block">
+    <p><strong><span id="prusammu_error_title">TITLE</span> (<span id="prusammu_error_code">CODE</span>)</strong></p>
+    <p id="prusammu_error_text"></p>
+    <p><a id="prusammu_error_url" href="#" target="_blank">URL</a></p>
+  </div>
 </div>
 <form class="form-horizontal">
   <h3>{{ _("Filament") }}</h3>


### PR DESCRIPTION

[Octoprint-PrusaMmu.zip](https://github.com/jukebox42/Octoprint-PrusaMMU/files/12504576/Octoprint-PrusaMmu.zip)
Enhanced the MMU 3.0.0 support with some needed fixes. Also now reports the error from the printer on the settings menu.

New Features:
- Reports the printer error in the header AND shows more details in the settings menu

Bug Fixes:
- Should now clear error in header when printer resets
- Better detects specific events so the header should get stuck less overall
- Fixed the duplicate event spamming

Internals:
- Copied the MMU error yaml. I had to comment a few out because they share hex codes. Future versions can probably fix this
- Added file with printer commands to make testing with virtual printer easier
- Added a few more checks to MMU state codes
    - INIT="MMU2:<X[0-4] F" - Notification that the MMU is done starting up. This gets spammed a lot
    - VERSION="MMU2<S3 A" - fires when printer/mmu restarts
    - ERROR="MMU2:<(?:[^E]*) (E[^*]*)" - format for an error message
- Added a LIVE_STATE to reduce the event spam because of how noisy 3.0.0 is. LIVE_STATE is synchronous, STATE is asynchronous 