### PR TITLE
Add some missing error codes

### DIFF
--- a/octoprint_prusammu/common/Mmu.py
+++ b/octoprint_prusammu/common/Mmu.py
@@ -11,22 +11,26 @@ class MmuStates():
   LOADING="LOADING"
   PAUSED_USER="PAUSED_USER"
   ATTENTION="ATTENTION"
+  LOADING_MMU="LOADING_MMU"
+  CUTTING="CUTTING"
+  EJECTING="EJECTING"
 
 
 class MmuKeys():
   STATE="state"
-  LIVE_STATE="liveState"
+  LAST_LINE="lastLine"
   TOOL="tool"
   PREV_TOOL="previousTool"
-  ERROR="error"
+  RESPONSE="response"
+  RESPONSE_DATA="responseData"
 
 DEFAULT_MMU_STATE = dict(
-  # liveState represents the state we have yet to advertise. Used to avoid event spamming with 3.0.0
-  liveState=MmuStates.NOT_FOUND,
   state=MmuStates.NOT_FOUND,
+  lastLine="",
   tool="",
   previousTool="",
-  error="",
+  response="",
+  responseData="",
 )
 
 class MMU2Commands():
@@ -40,59 +44,75 @@ class MMU2Commands():
   LOADED="OO succeeded"
 
 # https://github.com/prusa3d/Prusa-Firmware/blob/d84e3a9cf31963b9378b9cf39cd3dd4c948a05d6/Firmware/mmu2_protocol.h
-# The 3.0.0 software brings improved logging for the MMU. A command breakdown would look like:
-# MMU2:<L0 F0
+# The 3.0.0 software brings improved logging for the MMU. A response from the MMU would look like:
+# MMU2:<L0 P5
 # Which represents:
-# MMU2:(response) (command)(tool) (action)(tries)
+# MMU2:<(request)(request data) (response)(response data)
 # Using this we can determine:
-# The MMU (F)inished (L)oading Tool 0, and it only took 0(one) tries.
+# The MMU is (L)oading to MMU filament (0), and it is currently in (P)rogress with code (5), which translates to "Feeding to FINDA"
 class MMU3Codes():
-  INIT="MMU2:<X[0-4] F"
-  VERSION="MMU2<S3 A"
-  # Error
-  ERROR="MMU2:<(?:[^E]*) (E[^*]*)"
-  # Tool
-  # TODO: What's the different between Tool Finished and Load Finished? I don't see Load Finished in multi-color prints.
-  TOOL_START="MMU2:<T[0-4] A"
-  TOOL_PROCESSING="MMU2:<T[0-4] P"
-  TOOL_FINISHED="MMU2:<T[0-4] F"
-  # Load
-  LOAD_START="MMU2:<L[0-4] A"
-  LOAD_PROCESSING="MMU2:<:L[0-4] P"
-  LOAD_FINISHED="MMU2:<L[0-4] F"
-  # Unload
-  UNLOAD_START="MMU2:<U[0-4] A"
-  UNLOAD_PROCESSING="MMU2:<U[0-4] P"
-  UNLOAD_FINISHED="MMU2:<U[0-4] F"
+  # General check for MMU commands we care about. MMU2:< ensures that only messages FROM the MMU are detected. [TLUXKE] Matches a single character, only for request codes we care about
+  GENERAL_MATCH="MMU2:<[TLUXKE]"
+  # This regex match contains 4 groups. 
+  # MMU2:< ensures that only messages FROM the MMU are detected. 
+  # Group 1 is the single letter request code that the MMU is responding to. Only codes that we care about are checked for: T,L,U,X,K,E
+  # Group 2 is the request code data. It's usually 0 unless the code involves filament, then this contains the filament number (0-4)
+  # Group 3 is the response code. It shows that current status of the command the MMU is performing. Possible responses: P,E,F,A,R,B
+  # Group 4 is the response data. It contains extra info in hex depending on the response code. The amount of hex data can range, or even be empty! Check MMU3ResponseCodes below for more info
+  GROUP_MATCH="MMU2:<([TLUXKE])(.*) ([PEFARB])(.*)\*"
+  # These two lines can be used to tell that the MMU is stopped, waiting for user
+  SAVING_PARKING="MMU2:Saving and parking"
+  COOLDOWN_PENDING="MMU2:Heater cooldown pending"
+  # This is our only sign that the user is done with a PAUSED_USER event.
+  LCD_CHANGED="LCD status changed"
 
-class MMU3Commands():
-  INIT="Cap:PRUSA_MMU2:1"
-  ERROR="MMU2:Command Error"
-  BUTTON="MMU2:Button"
-  # Not technically an MMU command but tells us the last action was successful probably.
-  RESET_RETRY="ResetRetryAttempts"
-  # https://github.com/prusa3d/Prusa-Firmware/blob/d84e3a9cf31963b9378b9cf39cd3dd4c948a05d6/Firmware/mmu2_progress_converter.cpp#L8
-  OK="MMU2:OK"
-  ENGAGE_IDLER="MMU2:Engaging idler"
-  DISENGAGE_IDLER="MMU2:Disengaging idler"
-  UNLOAD_FINDA="MMU2:Unloading to FINDA"
-  UNLOAD_PULLEY="MMU2:Unloading to pulley"
-  FEED_FINDA="MMU2:Feeding to FINDA"
-  FEED_EXTRUDER="MMU2:Feeding to extruder"
-  FEED_NOZZLE="MMU2:Feeding to nozzle"
-  AVOID_GRIND="MMU2:Avoiding grind"
-  WAIT_USER="MMU2:ERR Wait for User"
-  ERR_INTERNAL="MMU2:ERR Internal"
-  ERR_HELP_FIL="MMU2:ERR Help filament"
-  ERR_TMC="MMU2:ERR TMC failed"
-  SELECT_SLOT="MMU2:Selecting fil. slot"
-  PREPARE_BLADE="MMU2:Preparing blade"
-  PUSH_FILAMENT="MMU2:Pushing filament"
-  PERFORM_CUT="MMU2:Performing cut"
-  RETURN_SELECTOR="MMU2:Returning selector"
-  PARK_SELECTOR="MMU2:Parking selector"
-  EJECT_FILAMENT="MMU2:Ejecting filament"
-  RETRACT_FINDA="MMU2:Retract from FINDA"
-  HOMING="MMU2:Homing"
-  MOVING_SELECTOR="MMU2:Moving selector"
-  FEED_FSENSOR="MMU2:Feeding to FSensor"
+# These request codes are commands sent by the printer to the MMU, but the MMU responds with the same code during the Q - Query request, and 
+# when responding to the request, so we can just listen for the MMU's responses to find out which action it's currently doing.
+# Codes are taken from here:
+# https://github.com/prusa3d/Prusa-Firmware/blob/MK3/Firmware/mmu2_protocol.h
+class MMU3RequestCodes():
+  # T -            Tool - Tells the MMU to load a filament from the MMU to the nozzle. Followed by the filament number 0-4. To test, use Gcode Tx, or M701 P#
+  TOOL="T"
+  # L -            Load - Tells the MMU to preload the filament to the MMU. Followed by the filament number 0-4. To test, use M704 P#
+  LOAD="L"
+  # U -          Unload - Tells the MMU to unload the current filament. Does NOT contain the filament number, it seems to always be 0. To test, use M702
+  UNLOAD="U"
+  # X -           Reset - Tells the MMU to reset itself. The MMU also responds to Query with this when it first boots. Seems to always be 0. To test, use M709 X0
+  RESET="X"
+  # K -             Cut - Tells the MMU to cut the filament. Followed by the filament number 0-4. To test, use M706 P#
+  CUT="K"
+  # E -           Eject - Tells the MMU to eject the filament (out of the front of the MMU). Followed by the filament number 0-4. To test use M705 P#
+  EJECT="E"
+  # Unused request codes. Most of these have no use to us:
+  # Q -           Query - Tells the MMU to respond with whatever request it's working on, and it's progress. The Printer sends this, but the MMU never seems to respond with this code, it replies with the working request instead
+  # M -            Mode - Theoretically used when the printer tells the MMU to change betweeen normal and stealth mode
+  # P -           Finda - Tells the MMU to send the Finda state
+  # S -         Version - Tells the MMU to send firmware version info. The printer sends these when the MMU is first connected. S0 = Major version. S1 = Minor S2 = Revision. S3 = Build number
+  # B -          Button - Tells the MMU to trigger a function, as if a button were pressed. B0=nothing. B1=Retry. B2=Continue. B3=ResetMMU. B4=Unload. B5=Load. B6=Eject. B7=Tune. B8=StopPrint. B9=DisableMMU
+  #                       Unfortunately there doesn't seem to be a way to trigger these via gcode, or it might be possible to resolve some errors remotely.
+  # W -           Write - Tells the MMU to write to a register. Check https://help.prusa3d.com/article/registers-mmu-mmu3_511780 for register info. You can trigger this via M708 A[ADDRESS] X[VALUE]
+  # F -   Filament Type - Theoretically tells the MMU to change the filament type. Apparently used for flex filaments and PVA. Maybe related to M403
+  # f - Filament Sensor - Tells the MMU the status of the Filament Sensor. The Printer sends this constantly during Tool/Unload commands.
+  # H -            Home - Theoretically tells the MMU to home itself. I've never seen this sent from the printer, and there doesn't seem to be a gcode command for it. The MMU usually homes itself when needed without sending a code
+  # R -            Read - Tells the MMU to read from a register. Lots of these during the normal 1 second MMU status checks. Check https://help.prusa3d.com/article/registers-mmu-mmu3_511780 for register info. You can trigger this via M707 A[ADDRESS]
+
+# These response codes follow a request code, and display the status of the request
+# The amount of response data can vary, depending on the request code
+class MMU3ResponseCodes():
+  # P - Processing - The MMU is still working on the request. The response data is a one or two digit hex code for the progress message
+  PROCESSING="P"
+  # E -      Error - The MMU had an error while working on the request. The response data is a 4 digit hex code for the error message
+  ERROR="E"
+  # F -   Finished - The MMU is done with the request. The response data seems to always be 0
+  FINISHED="F"
+  # A -   Accepted - The MMU has accepted the request. The response data varies depending on the command. I'll list the ones that I've figured out
+  #                  For T,L,U,K,E,B,W,f, there is no value to return, so the response data is empty!
+  #                  For R, the response data is an arbitrarially large amount of hex data that is the output of the address read.
+  #                  For S, the response data is an arbitrarially large amount of hex data representing the version info. Works the same way as R
+  #                  Unknown response types: M,P,F,H
+  ACCEPTED="A"
+  # R -   Rejected - The MMU has rejected the request, because it is busy. The easiest way to simulate this it to press a button on the MMU, then send a conflicting Gcode action. 
+  #                  The printer spams the next command until the MMU eventually takes it
+  REJECTED="R"
+  # B -     Button - Theoretically the MMU sends the pressed button to the printer for processing. I've never seen it in any log outputs
+  BUTTON="B"

--- a/octoprint_prusammu/static/mmuErrors.js
+++ b/octoprint_prusammu/static/mmuErrors.js
@@ -27,39 +27,42 @@ const getMmuError = (code) => {
  * to
  * https://raw.githubusercontent.com/prusa3d/Prusa-Error-Codes/master/04_MMU/error-codes.yaml
  * 
- * Missing codes or ones I couldn't figure out how to map start with an X.
+ * The Temperature and Electrical commands are mapped in a different way in the printer firmware, using bitmasks, since multiple error states can occur at once for those
+ * This could cause an error code that isn't in this list to appear, that is a mix of multiple errors. The Printer firmware deals with by doing bitwise checks for these errors, and only showing one error
+ * Since it would be a large change to fix this, for now I've just filled in the error info for single chip errors, since they're going to be most common anyway
+ * P.S. The printer firmware just gives a generic "More details online." description for most of these errors, to save memory, but we display the full info!
  */
 const MMU2MmuErrorStrings = {
   // MECHANICAL
-  E8001: {
+  "8001": {
     code:"04101",
     title:"FINDA DIDNT TRIGGER",
     text:"FINDA didn't trigger while loading the filament. Ensure the filament can move and FINDA works.",
     id:"FINDA_DIDNT_TRIGGER",
   },
 
-  E8002: {
+  "8002": {
     code:"04102",
     title:"FINDA FILAM. STUCK",
     text:"FINDA didn't switch off while unloading filament. Try unloading manually. Ensure filament can move and FINDA works.",
     id:"FINDA_FILAMENT_STUCK",
   },
 
-  E8003 : {
+  "8003": {
     code:"04103",
     title:"FSENSOR DIDNT TRIGG.",
     text:"Filament sensor didn't trigger while loading the filament. Ensure the sensor is calibrated and the filament reached it.",
     id:"FSENSOR_DIDNT_TRIGGER",
   },
 
-  E8004: {
+  "8004": {
     code:"04104",
     title:"FSENSOR FIL. STUCK",
     text:"Filament sensor didn't switch off while unloading filament. Ensure filament can move and the sensor works.",
     id:"FSENSOR_FILAMENT_STUCK",
   },
 
-  E8047: {
+  "8047": {
     code:"04105",
     title:"PULLEY CANNOT MOVE",
     text:"Pulley motor stalled. Ensure the pulley can move and check the wiring.",
@@ -67,56 +70,56 @@ const MMU2MmuErrorStrings = {
   },
 
   // This second E8xxx code causes the same error to be output
-  E804b: {
+  "804b": {
     code:"04105",
     title:"PULLEY CANNOT MOVE",
     text:"Pulley motor stalled. Ensure the pulley can move and check the wiring.",
     id:"PULLEY_CANNOT_MOVE",
   },
 
-  E8009: {
+  "8009": {
     code:"04106",
     title:"FSENSOR TOO EARLY",
     text:"Filament sensor triggered too early while loading to extruder. Check there isn't anything stuck in PTFE tube. Check that sensor reads properly.",
     id:"FSENSOR_TOO_EARLY",
   },
 
-  E800a: {
+  "800a": {
     code:"04107",
     title:"INSPECT FINDA",
     text:"Selector can't move due to FINDA detecting a filament. Make sure no filament is in Selector and FINDA works properly.",
     id:"INSPECT_FINDA",
   },
 
-  E802a: {
+  "802a": {
     code:"04108",
     title:"LOAD TO EXTR. FAILED",
     text:"Loading to extruder failed. Inspect the filament tip shape. Refine the sensor calibration, if needed.",
     id:"LOAD_TO_EXTRUDER_FAILED",
   },
 
-  E8087: {
+  "8087": {
     code:"04115",
     title:"SELECTOR CANNOT HOME",
     text:"The Selector cannot home properly. Check for anything blocking its movement.",
     id:"SELECTOR_CANNOT_HOME",
   },
 
-  E808b: {
+  "808b": {
     code:"04116",
     title:"SELECTOR CANNOT MOVE",
     text:"The Selector cannot move. Check for anything blocking its movement. Check if the wiring is correct.",
     id:"SELECTOR_CANNOT_MOVE",
   },
 
-  E8107: {
+  "8107": {
     code:"04125",
     title:"IDLER CANNOT HOME",
     text:"The Idler cannot home properly. Check for anything blocking its movement.",
     id:"IDLER_CANNOT_HOME",
   },
 
-  E810b: {
+  "810b": {
     code:"04126",
     title:"IDLER CANNOT MOVE",
     text:"The Idler cannot move properly. Check for anything blocking its movement. Check if the wiring is correct.",
@@ -125,7 +128,7 @@ const MMU2MmuErrorStrings = {
 
   // TEMPERATURE    xx2xx   // Temperature measurement
 
-  EA000: {
+  "A040": {
     code:"04201",
     title:"WARNING TMC TOO HOT",
     text:"TMC driver for the Pulley motor is almost overheating. Make sure there is sufficient airflow near the MMU board.",
@@ -133,7 +136,7 @@ const MMU2MmuErrorStrings = {
     id:"WARNING_TMC_PULLEY_TOO_HOT",
   },
 
-  /*EA000: {
+  "A080": {
     code:"04211",
     title:"WARNING TMC TOO HOT",
     text:"TMC driver for the Selector motor is almost overheating. Make sure there is sufficient airflow near the MMU board.",
@@ -141,15 +144,15 @@ const MMU2MmuErrorStrings = {
     id:"WARNING_TMC_SELECTOR_TOO_HOT",
   },
 
-  EA000: {
+  "A100": {
     code:"04221",
     title:"WARNING TMC TOO HOT",
     text:"TMC driver for the Idler motor is almost overheating. Make sure there is sufficient airflow near the MMU board.",
     text_short:"More details online.",
     id:"WARNING_TMC_IDLER_TOO_HOT",
-  },*/
+  },
 
-  EC000: {
+  "C040": {
     code:"04202",
     title:"TMC OVERHEAT ERROR",
     text:"TMC driver for the Pulley motor is overheated. Cool down the MMU board and reset MMU.",
@@ -157,7 +160,7 @@ const MMU2MmuErrorStrings = {
     id:"TMC_PULLEY_OVERHEAT_ERROR",
   },
 
-  /*EC000: {
+  "C080": {
     code:"04212",
     title:"TMC OVERHEAT ERROR",
     text:"TMC driver for the Selector motor is overheated. Cool down the MMU board and reset MMU.",
@@ -165,17 +168,17 @@ const MMU2MmuErrorStrings = {
     id:"TMC_SELECTOR_OVERHEAT_ERROR",
   },
 
-  EC000: {
+  "C100": {
     code:"04222",
     title:"TMC OVERHEAT ERROR",
     text:"TMC driver for the Idler motor is overheated. Cool down the MMU board and reset MMU.",
     text_short:"More details online.",
     id:"TMC_IDLER_OVERHEAT_ERROR",
-  },*/
+  },
 
   // ELECTRICAL     xx3xx
 
-  E8200: {
+  "8240": {
     code:"04301",
     title:"TMC DRIVER ERROR",
     text:"TMC driver for the Pulley motor is not responding. Try resetting the MMU. If the issue persists contact support.",
@@ -183,7 +186,7 @@ const MMU2MmuErrorStrings = {
     id:"TMC_PULLEY_DRIVER_ERROR",
   },
 
-  /*E8200: {
+  "8280": {
     code:"04311",
     title:"TMC DRIVER ERROR",
     text:"TMC driver for the Selector motor is not responding. Try resetting the MMU. If the issue persists contact support.",
@@ -191,15 +194,15 @@ const MMU2MmuErrorStrings = {
     id:"TMC_SELECTOR_DRIVER_ERROR",
   },
 
-  E8200: {
+  "8300": {
     code:"04321",
     title:"TMC DRIVER ERROR",
     text:"TMC driver for the Idler motor is not responding. Try resetting the MMU. If the issue persists contact support.",
     text_short:"More details online.",
     id:"TMC_IDLER_DRIVER_ERROR",
-  },*/
+  },
 
-  E8400: {
+  "8440": {
     code:"04302",
     title:"TMC DRIVER RESET",
     text:"TMC driver for the Pulley motor was restarted. There is probably an issue with the electronics. Check the wiring and connectors.",
@@ -207,7 +210,7 @@ const MMU2MmuErrorStrings = {
     id:"TMC_PULLEY_DRIVER_RESET",
   },
 
-  /*E8400: {
+  "8480": {
     code:"04312",
     title:"TMC DRIVER RESET",
     text:"TMC driver for the Selector motor was restarted. There is probably an issue with the electronics. Check the wiring and connectors.",
@@ -215,15 +218,15 @@ const MMU2MmuErrorStrings = {
     id:"TMC_SELECTOR_DRIVER_RESET",
   },
 
-  E8400: {
+  "8500": {
     code:"04322",
     title:"TMC DRIVER RESET",
     text:"TMC driver for the Idler motor was restarted. There is probably an issue with the electronics. Check the wiring and connectors.",
     text_short:"More details online.",
     id:"TMC_IDLER_DRIVER_RESET",
-  },*/
+  },
 
-  E8800: {
+  "8840": {
     code:"04303",
     title:"TMC UNDERVOLTAGE ERR",
     text:"Not enough current for the Pulley TMC driver. There is probably an issue with the electronics. Check the wiring and connectors.",
@@ -231,7 +234,7 @@ const MMU2MmuErrorStrings = {
     id:"TMC_PULLEY_UNDERVOLTAGE_ERROR",
   },
 
-  /*E8800: {
+  "8880": {
     code:"04313",
     title:"TMC UNDERVOLTAGE ERR",
     text:"Not enough current for the Selector TMC driver. There is probably an issue with the electronics. Check the wiring and connectors.",
@@ -239,15 +242,15 @@ const MMU2MmuErrorStrings = {
     id:"TMC_SELECTOR_UNDERVOLTAGE_ERROR",
   },
 
-  E8800: {
+  "8900": {
     code:"04323",
     title:"TMC UNDERVOLTAGE ERR",
     text:"Not enough current for the Idler TMC driver. There is probably an issue with the electronics. Check the wiring and connectors.",
     text_short:"More details online.",
     id:"TMC_IDLER_UNDERVOLTAGE_ERROR",
-  },*/
+  },
 
-  E9000: {
+  "9040": {
     code:"04304",
     title:"TMC DRIVER SHORTED",
     text:"Short circuit on the Pulley TMC driver. Check the wiring and connectors. If the issue persists contact support.",
@@ -255,7 +258,7 @@ const MMU2MmuErrorStrings = {
     id:"TMC_PULLEY_DRIVER_SHORTED",
   },
 
-  /*E9000: {
+  "9080": {
     code:"04314",
     title:"TMC DRIVER SHORTED",
     text:"Short circuit on the Selector TMC driver. Check the wiring and connectors. If the issue persists contact support.",
@@ -263,15 +266,15 @@ const MMU2MmuErrorStrings = {
     id:"TMC_SELECTOR_DRIVER_SHORTED",
   },
 
-  E9000: {
+  "9100": {
     code:"04324",
     title:"TMC DRIVER SHORTED",
     text:"Short circuit on the Idler TMC driver. Check the wiring and connectors. If the issue persists contact support.",
     text_short:"More details online.",
     id:"TMC_IDLER_DRIVER_SHORTED",
-  },*/
+  },
 
-  EC200: {
+  "C240": {
     code:"04305",
     title:"MMU SELFTEST FAILED",
     text:"MMU selftest failed on the Pulley TMC driver. Check the wiring and connectors. If the issue persists contact support.",
@@ -279,7 +282,7 @@ const MMU2MmuErrorStrings = {
     id:"MMU_PULLEY_SELFTEST_FAILED",
   },
 
-  /*EC200: {
+  "C280": {
     code:"04315",
     title:"MMU SELFTEST FAILED",
     text:"MMU selftest failed on the Selector TMC driver. Check the wiring and connectors. If the issue persists contact support.",
@@ -287,15 +290,15 @@ const MMU2MmuErrorStrings = {
     id:"MMU_SELECTOR_SELFTEST_FAILED",
   },
 
-  EC200: {
+  "C300": {
     code:"04325",
     title:"MMU SELFTEST FAILED",
     text:"MMU selftest failed on the Idler TMC driver. Check the wiring and connectors. If the issue persists contact support.",
     text_short:"More details online.",
     id:"MMU_IDLER_SELFTEST_FAILED",
-  },*/
+  },
 
-  E800d: {
+  "800d": {
     code:"04306",
     title:"MMU MCU ERROR",
     text:"MMU detected a power-related issue. Check the wiring and connectors. If the issue persists, contact support.",
@@ -305,14 +308,14 @@ const MMU2MmuErrorStrings = {
 
   // CONNECTIVITY
 
-  E802e: {
+  "802e": {
     code:"04401",
     title:"MMU NOT RESPONDING",
     text:"MMU not responding. Check the wiring and connectors.",
     id:"MMU_NOT_RESPONDING",
   },
 
-  E802d: {
+  "802d": {
     code:"04402",
     title:"COMMUNICATION ERROR",
     text:"MMU not responding correctly. Check the wiring and connectors.",
@@ -321,28 +324,28 @@ const MMU2MmuErrorStrings = {
 
   // SYSTEM
 
-  E8005: {
+  "8005": {
     code:"04501",
     title:"FIL. ALREADY LOADED",
     text:"Cannot perform the action, filament is already loaded. Unload it first.",
     id:"FILAMENT_ALREADY_LOADED",
   },
 
-  E8006: {
+  "8006": {
     code:"04502",
     title:"INVALID TOOL",
     text:"Requested filament tool is not available on this hardware. Check the G-code for tool index out of range (T0-T4},.",
     id:"INVALID_TOOL",
   },
 
-  E802b: {
+  "802b": {
     code:"04503",
     title:"QUEUE FULL",
     text:"MMU Firmware internal error, please reset the MMU.",
     id:"QUEUE_FULL",
   },
 
-  E802c: {
+  "802c": {
     code:"04504",
     title:"MMU FW UPDATE NEEDED",
     text:"The MMU firmware version is incompatible with the printer's FW. Update to compatible version.",
@@ -350,21 +353,21 @@ const MMU2MmuErrorStrings = {
     id:"FW_UPDATE_NEEDED",
   },
 
-  E802f: {
+  "802f": {
     code:"04505",
     title:"FW RUNTIME ERROR",
     text:"Internal runtime error. Try resetting the MMU or updating the firmware.",
     id:"FW_RUNTIME_ERROR",
   },
 
-  E8008: {
+  "8008": {
     code:"04506",
     title:"UNLOAD MANUALLY",
     text:"Filament detected unexpectedly. Ensure no filament is loaded. Check the sensors and wiring.",
     id:"UNLOAD_MANUALLY",
   },
 
-  E800c: {
+  "800c": {
     code:"04507",
     title:"FILAMENT EJECTED",
     text:"Remove the ejected filament from the front of the MMU.",
@@ -373,7 +376,7 @@ const MMU2MmuErrorStrings = {
 
   // Additional code reported in mmu firmware, but not listed in error-codes.yaml yet. Might need updated if it gets added. Values taken from https://github.com/prusa3d/Prusa-Firmware/blob/MK3/Firmware/mmu2/errors_list.h
 
-  E8029: {
+  "8029": {
     code:"04508",
     title:"FILAMENT CHANGE",
     text:"M600 Filament Change. Load a new filament or eject the old one.",

--- a/octoprint_prusammu/static/mmuErrors.js
+++ b/octoprint_prusammu/static/mmuErrors.js
@@ -59,12 +59,20 @@ const MMU2MmuErrorStrings = {
     id:"FSENSOR_FILAMENT_STUCK",
   },
 
-  /*X04105: {
+  E8047: {
     code:"04105",
     title:"PULLEY CANNOT MOVE",
     text:"Pulley motor stalled. Ensure the pulley can move and check the wiring.",
     id:"PULLEY_CANNOT_MOVE",
-  },*/
+  },
+
+  // This second E8xxx code causes the same error to be output
+  E804b: {
+    code:"04105",
+    title:"PULLEY CANNOT MOVE",
+    text:"Pulley motor stalled. Ensure the pulley can move and check the wiring.",
+    id:"PULLEY_CANNOT_MOVE",
+  },
 
   E8009: {
     code:"04106",
@@ -80,40 +88,40 @@ const MMU2MmuErrorStrings = {
     id:"INSPECT_FINDA",
   },
 
-  /*E802a: {
+  E802a: {
     code:"04108",
     title:"LOAD TO EXTR. FAILED",
     text:"Loading to extruder failed. Inspect the filament tip shape. Refine the sensor calibration, if needed.",
     id:"LOAD_TO_EXTRUDER_FAILED",
-  },*/
+  },
 
-  /*X04115: {
+  E8087: {
     code:"04115",
     title:"SELECTOR CANNOT HOME",
     text:"The Selector cannot home properly. Check for anything blocking its movement.",
     id:"SELECTOR_CANNOT_HOME",
-  },*/
+  },
 
-  /*X04116: {
+  E808b: {
     code:"04116",
     title:"SELECTOR CANNOT MOVE",
     text:"The Selector cannot move. Check for anything blocking its movement. Check if the wiring is correct.",
     id:"SELECTOR_CANNOT_MOVE",
-  },*/
+  },
 
-  /*X04125: {
+  E8107: {
     code:"04125",
     title:"IDLER CANNOT HOME",
     text:"The Idler cannot home properly. Check for anything blocking its movement.",
     id:"IDLER_CANNOT_HOME",
-  },*/
+  },
 
-  /*X04126: {
+  E810b: {
     code:"04126",
     title:"IDLER CANNOT MOVE",
     text:"The Idler cannot move properly. Check for anything blocking its movement. Check if the wiring is correct.",
     id:"IDLER_CANNOT_MOVE",
-  },*/
+  },
 
   // TEMPERATURE    xx2xx   // Temperature measurement
 
@@ -361,6 +369,15 @@ const MMU2MmuErrorStrings = {
     title:"FILAMENT EJECTED",
     text:"Remove the ejected filament from the front of the MMU.",
     id:"FILAMENT_EJECTED",
+  },
+
+  // Additional code reported in mmu firmware, but not listed in error-codes.yaml yet. Might need updated if it gets added. Values taken from https://github.com/prusa3d/Prusa-Firmware/blob/MK3/Firmware/mmu2/errors_list.h
+
+  E8029: {
+    code:"04508",
+    title:"FILAMENT CHANGE",
+    text:"M600 Filament Change. Load a new filament or eject the old one.",
+    id:"FILAMENT_CHANGE",
   },
 
   UNKNOWN: {

--- a/octoprint_prusammu/static/mmuProgress.js
+++ b/octoprint_prusammu/static/mmuProgress.js
@@ -1,0 +1,56 @@
+/**
+ * Given a progress code it returns a string to be displayed as a message in the navbar
+ * 
+ * @param {string} code - The progress code hexidecimal value as a string
+ * @returns string
+ */
+const getMmuProgress = (code) => {
+  try {
+    if (!code) {
+      return MMU2MmuProgressStrings["UNKNOWN"];
+    }
+
+    if (MMU2MmuProgressStrings[code]) {
+      return MMU2MmuProgressStrings[code];
+    }
+  } catch (e) { console.error(e); }
+
+  return MMU2MmuProgressStrings["UNKNOWN"];
+};
+/**
+ * The hex number determines the message. The below messages come from:
+ * https://github.com/prusa3d/Prusa-Firmware/blob/MK3/Firmware/mmu2_progress_converter.cpp
+ */
+const MMU2MmuProgressStrings = {
+
+  "0": "OK",
+  "1": "Engaging idler",
+  "2": "Disengaging idler",
+  "3": "Unloading to FINDA",
+  "4": "Unloading to pulley",
+  "5": "Feeding to FINDA",
+  "6": "Feeding to extruder",
+  "7": "Feeding to nozzle",
+  "8": "Avoiding grind",
+  "9": "Finishing movements",
+  "a": "Disengaging idler",
+  "b": "Engaging idler",
+  "c": "ERR Wait for User",
+  "d": "ERR Internal",
+  "e": "ERR Help filament",
+  "f": "ERR TMC failed",
+  "10": "Unloading filament",
+  "11": "Loading filament",
+  "12": "Selecting fil. slot",
+  "13": "Preparing blade",
+  "14": "Pushing filament",
+  "15": "Performing cut",
+  "16": "Returning selector",
+  "17": "Parking selector",
+  "18": "Ejecting filament",
+  "19": "Retract from FINDA",
+  "1a": "Homing",
+  "1b": "Moving selector",
+  "1c": "Feeding to FSensor",
+  UNKNOWN: "UNKNOWN",
+};

--- a/octoprint_prusammu/templates/prusammu_navbar.jinja2
+++ b/octoprint_prusammu/templates/prusammu_navbar.jinja2
@@ -17,4 +17,5 @@
     attr: { title: navActionText }
   "></i>
   <span data-bind="text: navActionText, hidden: isSimpleDisplayMode"></span>
+  <span data-bind="text: navMessageText, hidden: isSimpleDisplayMode"></span>
 </a>


### PR DESCRIPTION
I added some of the missing error codes.

I was going to add the TMC error codes, but it's a bit more complicated than I thought, and I'm not sure the best way to implement them. The best way to think about them is to convert them from hex to bits. 

Each TMC value listed in https://github.com/prusa3d/Prusa-Firmware/blob/4c531630686b4918ae442a27dce67c01f351c757/Firmware/mmu2/error_codes.h is actually a bitmask used in conjunction with the Pulley, Selector, and Idler bitmasks. For example:
`0xA000 = 1010000000000000 = Over Temperature Warn bitmask`
`0x0080 = 0000000010000000 = Selector bitmask`
And so
`0xA080 = 1010000010000000 = Selector TMC Driver Over Temperature Warn, AKA Prusa error code 04211`
An actual TMC driver error I have a log of is:
`0x8500 = 1000010100000000 = Idler TMC Driver Reset, AKA Prusa error code 04322`

It gets complicated though, since I guess multiple TMC errors can happen at the same time, so theoretically you could get:
`0x8D80 = 1000110110000000 = The selector and Idler TMC Drivers had an issue, where one was a Reset Error, and one was a Undervoltage on Charge Pump Error`, I think, it's pretty much impossible to test this stuff
The actual firmware as shown in https://github.com/prusa3d/Prusa-Firmware/blob/MK3/Firmware/mmu2_error_converter.cpp actually just reports whichever case it finds first, in order of decreasing severity. 

I'm not sure the best way to track this, maybe when a Exxxx error is found, convert the hex numbers to an int, then use the same bitmask method the firmware uses? In any case, the base errors like EA000 shouldn't ever show up in the serial log, since there would be a bit for selector/pulley/idler along with it.