### PR TITLE
Some cleanup, exposing the process javascript functions. Fix some missing icons. Add setting for the advanced info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Description:** This plugin adds Prusa MMU2 support to OctoPrint. The active filament will be
 displayed in the navbar and you will be prompted to select which filament to use when slicing in
 "MMU2S Single" mode. Other settings are available to name each tool and set defaults. This plugin
-only works for a Prusa printer with an MMU2.
+only works for a Prusa printer with an MMU2. Supports MMU firmware `1.X.X` and `3.X.X`.
 
 This plugin was inspired by the [MMU2filamentselect](https://plugins.octoprint.org/plugins/mmu2filamentselect/)
 plugin. I wanted to try and take it a step further.
@@ -211,6 +211,38 @@ Filament object properties:
   or spoolManager.
 - `color` - The color of the filament.
 - `enabled` Whether the filament is enabled in prusammu (when using prusammu as the source).
+
+#### `processMmuProgress(responseData)`
+
+Given the progress code it returns a string containing the progress message.
+
+If the value of `responseData` is one of [`P`, `E`, `F`, `A`, `R`] than you can pass `responseData`
+to get more details about the progress like `"Unloading to FINDA"`.
+
+Returns: `string`
+
+#### `processMmuError(responseData)`
+
+Given the error code it generates an error object with more information.
+
+If the value of `response` is `E` (Error) you can send this function `responseData` to get the
+error details.
+
+Returns:
+```javascript
+{
+  code: "04401",
+  title: "MMU NOT RESPONDING",
+  text: "MMU not responding. Check the wiring and connectors.",
+  url: `https://prusa.io/802e`,
+}
+```
+
+Object properties:
+- `code` - The error code.
+- `title` - The name of the error.
+- `text` - The description of the error.
+- `url` - The Prusa short url of the error. These are formatted like: `https://prusa.io/{code}`.
 
 ## Working on the PrusaMMU plugin
 

--- a/octoprint_prusammu/__init__.py
+++ b/octoprint_prusammu/__init__.py
@@ -481,6 +481,7 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
       useDefaultFilament=False,
       displayActiveFilament=True,
       simpleDisplayMode=False,
+      advancedDisplayMode=True,
       defaultFilament=-1,
       indexAtZero=False,
       classicColorPicker=False,
@@ -529,6 +530,8 @@ class PrusaMMUPlugin(octoprint.plugin.StartupPlugin,
     self.config[SettingsKeys.DEBUG] = self._settings.get_boolean([SettingsKeys.DEBUG])
     self.config[SettingsKeys.SIMPLE_DISPLAY_MODE] = self._settings.get_boolean([
       SettingsKeys.SIMPLE_DISPLAY_MODE])
+    self.config[SettingsKeys.ADVANCED_DISPLAY_MODE] = self._settings.get_boolean([
+      SettingsKeys.ADVANCED_DISPLAY_MODE])
 
     self.config[SettingsKeys.TIMEOUT] = self._settings.get_int([SettingsKeys.TIMEOUT])
     self.config[SettingsKeys.USE_DEFAULT_FILAMENT] = self._settings.get_boolean([

--- a/octoprint_prusammu/common/SettingsKeys.py
+++ b/octoprint_prusammu/common/SettingsKeys.py
@@ -8,6 +8,7 @@ class SettingsKeys():
   USE_DEFAULT_FILAMENT="useDefaultFilament"
   DISPLAY_ACTIVE_FILAMENT="displayActiveFilament"
   SIMPLE_DISPLAY_MODE="simpleDisplayMode"
+  ADVANCED_DISPLAY_MODE="advancedDisplayMode"
   DEFAULT_FILAMENT="defaultFilament"
   FILAMENT_SOURCE="filamentSource"
   FILAMENT_SOURCES="filamentSources"

--- a/octoprint_prusammu/static/prusammu.js
+++ b/octoprint_prusammu/static/prusammu.js
@@ -50,6 +50,7 @@ $(() => {
     self.modal = undefined;
 
     self.isSimpleDisplayMode = ko.observable(false);
+    self.isAdvancedDisplayMode = ko.observable(true);
     self.shouldShowNav = ko.observable(false);
 
     self.navActionText = ko.observable("Not Found");
@@ -128,7 +129,14 @@ $(() => {
       }
 
       // Action Icon only shows global states
-      if (state === STATES.UNLOADING || state === STATES.LOADING || state === STATES.LOADED || state === STATES.LOADING_MMU || state === STATES.CUTTING || state === STATES.EJECTING) {
+      if (
+        state === STATES.UNLOADING ||
+        state === STATES.LOADING ||
+        state === STATES.LOADED ||
+        state === STATES.LOADING_MMU ||
+        state === STATES.CUTTING ||
+        state === STATES.EJECTING
+      ) {
         return ""
       }
       
@@ -191,8 +199,8 @@ $(() => {
         [STATES.UNLOADING]: "fa-long-arrow-alt-up",
         [STATES.LOADING]: "fa-long-arrow-alt-down",
         [STATES.LOADING_MMU]: "fa-long-arrow-alt-right",
-        [STATES.CUTTING]: "fa-scissors",
-        [STATES.EJECTING]: "fa-angles-up",
+        [STATES.CUTTING]: "fa-cut",
+        [STATES.EJECTING]: "fa-eject",
       };
       if (Object.keys(iconStates).indexOf(state) !== -1) {
         return iconStates[state];
@@ -210,9 +218,9 @@ $(() => {
     const getNavMessageText = (response, responseData) => {
       switch (response) {
         case RESPONSES.PROCESSING:
-          return processMmuProgress(responseData);
+          return self.processMmuProgress(responseData);
         case RESPONSES.ERROR:
-          return processMmuError(responseData).title;
+          return self.processMmuError(responseData).title;
         case RESPONSES.FINISHED:
           // Return blank string if finished. It looks nicer
           return "";
@@ -291,7 +299,13 @@ $(() => {
       log(
         "updateNav",
         { 
-          "params": { "tool": toolId, "previousTool": previousToolId, "state": state, "response": response, "responseData": responseData},
+          "params": {
+            "tool": toolId,
+            "previousTool": previousToolId,
+            "state": state,
+            "response": response,
+            "responseData": responseData
+          },
           "currentFilament": currentFilament,
           "previousFilament": previousFilament,
           "action": { "text": self.navActionText(), "icon": self.navActionIcon() },
@@ -329,7 +343,13 @@ $(() => {
       setTimeout(() => {
         log(
           "delayedRefreshNav", self.filamentRetryCount,
-          { "state": self._toolState, "tool": self._toolId, "prevTool": self._previousToolId, "response": self._response, "responseData": self._responseData  }
+          { 
+            "state": self._toolState,
+            "tool": self._toolId,
+            "prevTool": self._previousToolId,
+            "response": self._response,
+            "responseData": self._responseData
+          }
         );
         updateNav(self._toolState, self._toolId, self._previousToolId, self._response, self._responseData);
       }, 1000 * self.filamentRetryCount);
@@ -439,6 +459,7 @@ $(() => {
       log("onSettingsBeforeSave");
       self.shouldShowNav(self.settings.displayActiveFilament());
       self.isSimpleDisplayMode(self.settings.simpleDisplayMode());
+      self.isAdvancedDisplayMode(self.settings.advancedDisplayMode() && !self.settings.simpleDisplayMode());
     };
 
     /**
@@ -643,7 +664,7 @@ $(() => {
         return;
       }
 
-      const error = processMmuError(self._responseData);
+      const error = self.processMmuError(self._responseData);
       $(`${idPrefix}title`).text(error.title);
       $(`${idPrefix}code`).text(error.code);
       $(`${idPrefix}text`).text(error.text);
@@ -657,7 +678,7 @@ $(() => {
      * @param {string} code - The error code hexidecimal value as a string
      * @returns {code, title, text, url}
      */
-    const processMmuError = (code) => {
+    self.processMmuError = (code) => {
       const error = getMmuError(code);
       return {
         code: error.code,
@@ -668,15 +689,12 @@ $(() => {
     };
 
    /**
-    * Given the progress code it returns a string contraining the progress message
+    * Given the progress code it returns a string containing the progress message
     *
     * @param {string} code - The progress code hexidecimal value as a string
     * @returns string
     */
-    const processMmuProgress = (code) => {
-      const progress = getMmuProgress(code);
-      return progress;
-    };
+    self.processMmuProgress = (code) => getMmuProgress(code);
 
     /**
      * Simple function to log out debug messages if debug is on. Use like you would console.log().

--- a/octoprint_prusammu/templates/prusammu_navbar.jinja2
+++ b/octoprint_prusammu/templates/prusammu_navbar.jinja2
@@ -17,6 +17,6 @@
     attr: { title: navActionText }
   "></i>
   <span data-bind="text: navActionText, hidden: isSimpleDisplayMode"></span>
-  <i class="fas fa-arrow-right" data-bind="hidden: navMessageText() == '' || isSimpleDisplayMode"></i>
-  <span data-bind="text: navMessageText, hidden: isSimpleDisplayMode"></span>
+  <i class="fas fa-chevron-right" data-bind="visible: isAdvancedDisplayMode() && navMessageText() != ''"></i>
+  <span data-bind="text: navMessageText, visible: isAdvancedDisplayMode"></span>
 </a>

--- a/octoprint_prusammu/templates/prusammu_settings.jinja2
+++ b/octoprint_prusammu/templates/prusammu_settings.jinja2
@@ -121,6 +121,16 @@
     </div>
   </div>
 
+  <div class="control-group" data-bind="visible: !settings.plugins.prusammu.simpleDisplayMode()">
+    <div class="controls">
+      <label class="checkbox">
+        <input type="checkbox" data-bind="checked: settings.plugins.prusammu.advancedDisplayMode" />
+        {{ _("Advanced display mode") }}
+      </label>
+      <span class="help-block">{{ _("Check to show more precise details about the MMU (Only works with 3.0.0).") }}</span>
+    </div>
+  </div>
+
   <div>
     <div>
       <small>


### PR DESCRIPTION
Just some cleanup from the last release. There's a few missing icons because of how old octoprint's fa lib is.

New Features:
- Added setting to disable advanced data display (on by default).

Bug Fixes:
- Fixed missing cut icon, arrow icon, eject icon.

Internals:
- Exposed the process functions so they can be used if needed by other plugins.