### PR TITLE
Update the popup to be rewritten instead of a new one each error

### DIFF
--- a/octoprint_prusammu/static/mmuErrors.js
+++ b/octoprint_prusammu/static/mmuErrors.js
@@ -33,7 +33,7 @@ const getMmuError = (code) => {
  * P.S. The printer firmware just gives a generic "More details online." description for most of these errors, to save memory, but we display the full info!
  */
 const MMU2MmuErrorStrings = {
-  // MECHANICAL
+  // MECHANICAL     XX1XX
   "8001": {
     code:"04101",
     title:"FINDA DIDNT TRIGGER",
@@ -306,7 +306,7 @@ const MMU2MmuErrorStrings = {
     id:"MCU_POWER_ERROR",
   },
 
-  // CONNECTIVITY
+  // CONNECTIVITY     XX4XX
 
   "802e": {
     code:"04401",
@@ -322,7 +322,7 @@ const MMU2MmuErrorStrings = {
     id:"COMMUNICATION_ERROR",
   },
 
-  // SYSTEM
+  // SYSTEM     XX5XX
 
   "8005": {
     code:"04501",
@@ -382,6 +382,8 @@ const MMU2MmuErrorStrings = {
     text:"M600 Filament Change. Load a new filament or eject the old one.",
     id:"FILAMENT_CHANGE",
   },
+
+  // UNKNOWN      XX9XX
 
   UNKNOWN: {
     code:"04900",

--- a/octoprint_prusammu/static/prusammu.js
+++ b/octoprint_prusammu/static/prusammu.js
@@ -369,21 +369,35 @@ $(() => {
       }, 1000 * self.filamentRetryCount);
     };
 
+    // A hacky way to avoid spamming the user with errors.
+    let _notifyEle = undefined;
+
     /**
      * When we get an error, show a popup as well with the link.
+     * 
+     * This function will rewrite the error the user sees if a new error pops in and they already
+     * have one from us. users only really need the last error.
      * 
      * @param {object} mmuError - The error object
      */
     const showErrorPopupNotification = (mmuError) => {
-      // TODO: Disabled the error notification for now. We need to handle not spamming the user on retry
-      //       Maybe we dont show errors that are retried until the final try?
-      /*new PNotify({
-        title: `Prusa MMU: ${mmuError.title} (#${mmuError.code})`,
-        text: `<p>${mmuError.text}</p>` +
-              `<p><a target="_blank" href="${mmuError.url}">${mmuError.url}</a></p>`,
-        type: "error",
-        hide: false,
-      });*/
+      const title = `Prusa MMU: ${mmuError.title} (#${mmuError.code})`;
+      const text = `<p>${mmuError.text}</p>` +
+                   `<p><a target="_blank" href="${mmuError.url}">${mmuError.url}</a></p>`;
+      if (!_notifyEle) {
+        _notifyEle = new PNotify({ title, text, type: "error", hide: false });
+        return;
+      }
+      // Doesn't do anything, for house keeping.
+      _notifyEle.options.title = title;
+      _notifyEle.options.text = text;
+      // Actually sets the values.
+      _notifyEle.title_container.text(title);
+      _notifyEle.text_container.html(text);
+      // If they had closed it show it again.
+      if (_notifyEle.state !== "open") {
+        _notifyEle.open();
+      }
     };
 
     /* =============================


### PR DESCRIPTION
To avoid a [popup spam issue](https://github.com/jukebox42/Octoprint-PrusaMMU/issues/41), instead of generating a new popup every time we see an error, we're going to rewrite the error being showing. The last error shown is likely the only one the user needs.

