### PR TITLE
Add a setting for overriding the version being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ events and printer notifications, so it can update the navbar: (`gcode_received_
    display. You will still be able to select the filament directly on the printer.
 1. `MK3` printers will look like `MK3S` in the debug logs. They operate the same, this was easier
    to implement.
+1. If the plugin is having trouble detecting the version of Prusa you have, use `Prusa Version` 
+   option in settings to fix it to a version.
 
 ## Developer Zone
 

--- a/octoprint_prusammu/common/PrusaProfile.py
+++ b/octoprint_prusammu/common/PrusaProfile.py
@@ -8,7 +8,6 @@ class MachineType():
   MK3_5="MK3.5"
   MK3_9="MK3.9"
   MK4="MK4"
-  MK4S="MK4S"
 
   # Print Profile (or the profile of the printer in the gcode)
 class PrusaProfile():
@@ -23,7 +22,7 @@ def detect_connection_profile(machine_type):
     return PrusaProfile.MK3_5
   if MachineType.MK3_9 in machine_type:
     return PrusaProfile.MK3_9
-  if MachineType.MK4S in machine_type or MachineType.MK4 in machine_type:
+  if MachineType.MK4 in machine_type:
     return PrusaProfile.MK4
   # Fallback to the MK3
   return PrusaProfile.MK3

--- a/octoprint_prusammu/common/SettingsKeys.py
+++ b/octoprint_prusammu/common/SettingsKeys.py
@@ -16,3 +16,4 @@ class SettingsKeys():
   FILAMENT_MAP="filamentMap"
   USE_FILAMENT_MAP="useFilamentMap"
   ENABLE_PROMPT="enablePrompt"
+  PRUSA_VERSION="prusaVersion"

--- a/octoprint_prusammu/static/prusammu.js
+++ b/octoprint_prusammu/static/prusammu.js
@@ -538,6 +538,7 @@ $(() => {
         $("#settings_plugin_prusammu .mk3").addClass("hide");
         $("#settings_plugin_prusammu .mk4").removeClass("hide");
       }
+      $("#settings_plugin_prusammu .prusa-version").text(self._prusaVersion ? self._prusaVersion.replace("_", ".") : "...");
     };
 
     /**

--- a/octoprint_prusammu/templates/prusammu_settings.jinja2
+++ b/octoprint_prusammu/templates/prusammu_settings.jinja2
@@ -11,6 +11,7 @@
   <p>You MUST use the MMU3 profile for single filament prints. Slicing without MMU will not work with this plugin. The popup will rewrite all filament to the chosen one. For multi-mode use the skip button.</p>
 </div>
 <form class="form-horizontal">
+
   <h3>{{ _("Filament") }}</h3>
 
   <div class="control-group">
@@ -129,6 +130,35 @@
         {{ _("Advanced display mode") }}
       </label>
       <span class="help-block">{{ _("Check to show more precise details about the MMU (Only works with 3.0.0).") }}</span>
+    </div>
+  </div>
+
+  <h3>Prusa</h3>
+
+  <div class="alert alert-block" data-bind="visible: settings.plugins.prusammu.prusaVersion() === ''">
+    <p><i class="fas fa-info-circle"></i> Detected Version: <span class="prusa-version">...</span></p>
+  </div>
+
+  <div class="control-group">
+    <label class="control-label">{{ _("Prusa Version") }}</label>
+    <div class="controls">
+      <select data-bind="
+        options: [
+          {key: 'auto detect', value: ''},
+          {key: 'MK3', value: 'MK3'},
+          {key: 'MK3.5', value: 'MK3_5'},
+          {key: 'MK3.9', value: 'MK3_9'},
+          {key: 'MK4', value: 'MK4'},
+        ],
+        optionsText: function(opt) {
+          return opt.key;
+        },
+        optionsValue: function(opt) {
+          return opt.value;
+        },
+        value: settings.plugins.prusammu.prusaVersion,
+      "></select>
+      <span class="help-block">{{ _("Sometimes version detection can have trouble, you can lock the version with this setting. \"S\" versions operate the same as their non-\"S\" counterparts.") }}</span>
     </div>
   </div>
 


### PR DESCRIPTION
Improve detection for the Prusa version by adding additional checkpoints and simplifying how it's pulled.

New Features:

- Add the ability to override the prusa version being detected.

Bug Fixes:

- Fix the OK for mk4s

Internals:

- N/A