### PR TITLE
Allow more than 5 filament on the MMU

### DIFF
--- a/octoprint_prusammu/common/SettingsKeys.py
+++ b/octoprint_prusammu/common/SettingsKeys.py
@@ -14,6 +14,7 @@ class SettingsKeys():
   FILAMENT_SOURCES="filamentSources"
   FILAMENT="filament"
   FILAMENT_MAP="filamentMap"
+  FILAMENT_COUNT="filamentCount"
   USE_FILAMENT_MAP="useFilamentMap"
   ENABLE_PROMPT="enablePrompt"
   PRUSA_VERSION="prusaVersion"

--- a/octoprint_prusammu/static/colorPick.js
+++ b/octoprint_prusammu/static/colorPick.js
@@ -21,9 +21,9 @@
   $.colorPick = function (element, options) {
     options = options || {};
     this.settings = $.extend({}, $.fn.colorPick.defaults, options);
-    this.settings.palette = this.settings.palette.map(x => x.toUpperCase());
+    this.settings.palette = this.settings.palette.map(x => x?.toUpperCase() || "#C0C0C0");
 
-    this.color   = this.settings.initialColor.toUpperCase();
+    this.color   = this.settings.initialColor?.toUpperCase();
     this.element = $(element);
 
     return this.element.hasClass(PICKER_CLASS) ? this : this.init();

--- a/octoprint_prusammu/static/colorPick.js
+++ b/octoprint_prusammu/static/colorPick.js
@@ -21,9 +21,9 @@
   $.colorPick = function (element, options) {
     options = options || {};
     this.settings = $.extend({}, $.fn.colorPick.defaults, options);
-    this.settings.palette = this.settings.palette.map(x => x?.toUpperCase() || "#C0C0C0");
+    this.settings.palette = this.settings.palette.map(x => x.toUpperCase());
 
-    this.color   = this.settings.initialColor?.toUpperCase();
+    this.color   = this.settings.initialColor.toUpperCase();
     this.element = $(element);
 
     return this.element.hasClass(PICKER_CLASS) ? this : this.init();

--- a/octoprint_prusammu/static/prusammu.js
+++ b/octoprint_prusammu/static/prusammu.js
@@ -352,9 +352,10 @@ $(() => {
      *                                                                 (see getFilamentList())
      */
     self.delayedRefreshNav = (filamentList) => {
+      const filamentCount = parseInt(self.settings.filamentCount(), 10);
       if (
         self.filamentRetryCount++ >= MAX_FILAMENT_RETRY ||
-        (filamentList.length >= 5 && !filamentList.includes(null))
+        (filamentList.length >= filamentCount && !filamentList.includes(null))
       ) {
         return;
       }
@@ -566,6 +567,7 @@ $(() => {
      */
     self.getFilamentList = () => {
       let filament = [];
+      const filamentCount = parseInt(self.settings.filamentCount(), 10);
       filament = self.settings.filament().map(f => {
         return {
           enabled: f.enabled(),
@@ -584,7 +586,7 @@ $(() => {
         try {
           const spools = self.filamentSources.filamentManager.selectedSpools();
           spools?.forEach((spool, i) => {
-            if (!spool || i >= 5) {
+            if (!spool || i >= filamentCount) {
               return;
             }
             filament.push({
@@ -658,13 +660,10 @@ $(() => {
 
       // Catchall if we got zero back, default to showing something.
       if (filament.length === 0) {
-        filament = [
-          {id: 1, index: 0, name: "", type: "", color: "", enabled: true},
-          {id: 2, index: 1, name: "", type: "", color: "", enabled: true},
-          {id: 3, index: 2, name: "", type: "", color: "", enabled: true},
-          {id: 4, index: 3, name: "", type: "", color: "", enabled: true},
-          {id: 5, index: 4, name: "", type: "", color: "", enabled: true},
-        ];
+        filament = [];
+        for (const i = 0; i < parseInt(self.settings.filamentCount(), 10); i++) {
+          filament.push({id: i + 1, index: i, name: "", type: "", color: "", enabled: true});
+        }
         log("getFilament fallback", filament);
       }
 

--- a/octoprint_prusammu/static/prusammu.js
+++ b/octoprint_prusammu/static/prusammu.js
@@ -247,8 +247,8 @@ $(() => {
      * @param {string} previousTool - The previous tool id. It _might_ have a T so we strip it here
      */
     const updateNav = (state, tool, previousTool, response, responseData) => {
-      const toolId = parseInt(tool, 10);
-      const previousToolId = parseInt(previousTool, 10);
+      const toolId = parseInt(tool, 16); // tool numbers are 16 bit from Prusa
+      const previousToolId = parseInt(previousTool, 16); // tools are 16 bit from Prusa
       // Remember these, we may need them again
       self._toolId = toolId;
       self._previousToolId = previousToolId;
@@ -632,7 +632,7 @@ $(() => {
           if (f.multi_color_hexes) {
             return `#${f.multi_color_hexes.split(",")[0].replace("#","")}`;
           }
-          return "#999999";
+          return "#C0C0C0";
         }
 
         filament = [];
@@ -701,7 +701,7 @@ $(() => {
      *                                                              the tool (see getFilamentList())
      */
     const getFilamentDisplayColor = (filament) => {
-      return filament && filament.color ? filament.color : "#999999";
+      return filament && filament.color ? filament.color : "#C0C0C0";
     }
 
     /* =============================
@@ -745,7 +745,7 @@ $(() => {
       ];
       $("#settings_plugin_prusammu .color-dropdown").each((index, element) => {
         $(element).colorPick({
-          initialColor: self.settings.filament()[index].color(),
+          initialColor: self.settings.filament()[index].color() || "#C0C0C0",
           paletteLabel: gettext("Filament color:"),
           customLabel: gettext("Custom color:"),
           recentLabel: gettext("Recent color:"),

--- a/octoprint_prusammu/static/prusammu.js
+++ b/octoprint_prusammu/static/prusammu.js
@@ -632,7 +632,7 @@ $(() => {
           if (f.multi_color_hexes) {
             return `#${f.multi_color_hexes.split(",")[0].replace("#","")}`;
           }
-          return "#C0C0C0";
+          return "#999999";
         }
 
         filament = [];
@@ -701,7 +701,7 @@ $(() => {
      *                                                              the tool (see getFilamentList())
      */
     const getFilamentDisplayColor = (filament) => {
-      return filament && filament.color ? filament.color : "#C0C0C0";
+      return filament && filament.color ? filament.color : "#999999";
     }
 
     /* =============================

--- a/octoprint_prusammu/templates/prusammu_settings.jinja2
+++ b/octoprint_prusammu/templates/prusammu_settings.jinja2
@@ -100,7 +100,7 @@
         value: settings.plugins.prusammu.defaultFilament,
         optionsCaption: 'Choose...'
       "></select>
-      <span class="help-block">{{ _("Check if you want octoprint to default to a specific filament when the dialog times out.") }}</span>
+      <span class="help-block">{{ _("Check if you want Octoprint to default to a specific filament when the dialog times out.") }}</span>
       <span class="help-block hide mk4"><i class="fas fa-warning"></i> {{ _("Does not work for MK3.5/3.9/4 users because of how single select works.") }}</span>
     </div>
   </div>
@@ -200,7 +200,7 @@
             <input type="checkbox" data-bind="checked: settings.plugins.prusammu.indexAtZero" />
             {{ _("Index at zero") }}
           </label>
-          <span class="help-block">{{ _("Check to have the filament numbers be 0-4 instead of 1-5. Plugins like Spool Manager as well as the actual GCode refrence them as 0-4.") }}</span>
+          <span class="help-block">{{ _("Check to have the filament numbers be 0-4 instead of 1-5. Plugins like Spool Manager as well as the actual GCode reference them as 0-4.") }}</span>
         </div>
       </div>
 
@@ -260,6 +260,17 @@
               </div>
             </div>
           </div>
+        </div>
+      </div>
+
+      <div class="control-group">
+        <label class="control-label">{{ _("Filament Count") }}</label>
+        <div class="controls">
+          <div class="input-append">
+            <input type="number" min="1" pattern="[0-9]+" class="input-mini text-right" class="input-block-level" data-bind="value: settings.plugins.prusammu.filamentCount">
+          </div>
+          <span class="help-block">{{ _("The number of filament on your MMU unit. Only change this if you have modded your MMU to have more or less filament. The default is 5.") }}</span>
+          <span class="help-block">{{ _("To use this setting. Set the number to the correct filament count, save it. Then come back into settings to see the new filament slots available.") }}</span>
         </div>
       </div>
 


### PR DESCRIPTION
Allow support for more than 5 filament on the MMU

New Features:

- Allow support for more than 5 filament on the MMU

Bug Fixes:

-N/A

Internals:

- Added new setting filamentCount to manage the filament length
- Filament list is updated on save (requires saving twice to get the desired outcome, something to fix later)